### PR TITLE
Upgrade to rspec 3

### DIFF
--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Admin::ProductsController do
   describe "on :index" do
     it "renders index" do
       spree_get :index
-      response.should be_success
+      expect(response).to be_success
     end
   end
 
@@ -23,7 +23,7 @@ describe Spree::Admin::ProductsController do
         spree_put :update, :id => @product.to_param,
                       :product => {:name => @product.name}, update_store_ids: 'true'
 
-        @product.reload.store_ids.should be_empty
+        expect(@product.reload.store_ids).to be_empty
       end
     end
 
@@ -32,7 +32,7 @@ describe Spree::Admin::ProductsController do
         spree_put :update, :id => @product.to_param,
                       :product => {:name => @product.name, :store_ids => [@store.id]}, update_store_ids: 'true'
 
-        @product.reload.store_ids.should == [@store.id]
+        expect(@product.reload.store_ids) == [@store.id]
       end
     end
 
@@ -42,7 +42,7 @@ describe Spree::Admin::ProductsController do
 
         spree_put :update, :id => @product.to_param, :product => {:name => "Test"}
 
-        @product.reload.store_ids.should == [@store.id]
+        expect(@product.reload.store_ids) == [@store.id]
       end
     end
   end

--- a/spec/controllers/spree/admin/stores_controller_spec.rb
+++ b/spec/controllers/spree/admin/stores_controller_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Admin::StoresController do
   describe "on :index" do
     it "renders index" do
       spree_get :index
-      response.should be_success
+      expect(response).to be_success
     end
   end
 end

--- a/spec/controllers/spree/api/products_controller_spec.rb
+++ b/spec/controllers/spree/api/products_controller_spec.rb
@@ -13,7 +13,7 @@ describe Spree::Api::ProductsController do
     it 'should return 404' do
       spree_get :show, :id => product.to_param, format: :json
 
-      response.response_code.should == 404
+      expect(response.response_code) == 404
     end
   end
 
@@ -30,7 +30,7 @@ describe Spree::Api::ProductsController do
       controller.stub(:current_store => store_2)
       spree_get :show, :id => product.to_param, format: :json
 
-      response.response_code.should == 404
+      expect(response.response_code) == 404
     end
   end
 
@@ -45,7 +45,7 @@ describe Spree::Api::ProductsController do
       controller.stub(:current_store => store)
       spree_get :show, :id => product.to_param, format: :json
 
-      response.response_code.should == 200
+      expect(response.response_code) == 200
     end
   end
 

--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -10,7 +10,7 @@ describe Spree::ProductsController do
     it 'should return 404' do
       spree_get :show, :id => product.to_param
 
-      response.response_code.should == 404
+      expect(response.response_code) == 404
     end
   end
 
@@ -27,7 +27,7 @@ describe Spree::ProductsController do
       controller.stub(:current_store => store_2)
       spree_get :show, :id => product.to_param
 
-      response.response_code.should == 404
+      expect(response.response_code) == 404
     end
   end
 
@@ -42,7 +42,7 @@ describe Spree::ProductsController do
       controller.stub(:current_store => store)
       spree_get :show, :id => product.to_param
 
-      response.response_code.should == 200
+      expect(response.response_code) == 200
     end
   end
 

--- a/spec/helpers/products_helper_decorator_spec.rb
+++ b/spec/helpers/products_helper_decorator_spec.rb
@@ -14,8 +14,8 @@ module Spree
       it "only show taxonomies on current_store" do
         taxonomies = helper.get_taxonomies
 
-        taxonomies.should include(@taxonomy)
-        taxonomies.should_not include(@taxonomy2)
+        expect(taxonomies).to include(@taxonomy)
+        expect(taxonomies).not_to include(@taxonomy2)
       end
     end
   end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -16,7 +16,7 @@ describe Spree::LineItem do
       let(:product) { create(:product, stores: [order_store])}
 
       it 'does not raise an error' do
-        expect{ subject }.to_not raise_error(SpreeMultiDomain::LineItemDecorator::ProductDoesNotBelongToStoreError)
+        expect{ subject }.to_not raise_error
       end
     end
 
@@ -32,7 +32,7 @@ describe Spree::LineItem do
       let(:product) { create(:product, stores: [order_store])}
 
       it "does not raise an error" do
-        expect{ subject }.to_not raise_error(SpreeMultiDomain::LineItemDecorator::ProductDoesNotBelongToStoreError)
+        expect{ subject }.to_not raise_error
       end
     end
   end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -12,7 +12,7 @@ describe Spree::Order do
   it 'should correctly find products by store' do
     by_store = Spree::Order.by_store(@store)
 
-    by_store.should include(@order)
-    by_store.should_not include(@order2)
+    expect(by_store).to include(@order)
+    expect(by_store).not_to include(@order2)
   end
 end

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -12,7 +12,7 @@ describe Spree::Product do
   it 'should correctly find products by store' do
     products_by_store = Spree::Product.by_store(@store)
 
-    products_by_store.should include(@product)
-    products_by_store.should_not include(@product2)
+    expect(products_by_store).to include(@product)
+    expect(products_by_store).not_to include(@product2)
   end
 end

--- a/spec/models/spree/store_spec.rb
+++ b/spec/models/spree/store_spec.rb
@@ -2,15 +2,15 @@ require 'spec_helper'
 
 describe Spree::Store do
 
-  describe "by_domain" do 
+  describe "by_domain" do
     let!(:store)    { FactoryGirl.create(:store, :domains => "website1.com\nwww.subdomain.com") }
     let!(:store_2)  { FactoryGirl.create(:store, :domains => 'freethewhales.com') }
 
     it "should find stores by domain" do
       by_domain = Spree::Store.by_domain('www.subdomain.com')
 
-      by_domain.should include(store)
-      by_domain.should_not include(store_2)
+      expect(by_domain).to include(store)
+      expect(by_domain).not_to include(store_2)
     end
   end
 
@@ -19,15 +19,15 @@ describe Spree::Store do
     let!(:store_2)  { FactoryGirl.create(:store, default: true) }
 
     it "should ensure there is a default if one doesn't exist yet" do
-      store.default.should be_true
+      expect(store.default).to be_truthy
     end
 
     it "should ensure there is only one default" do
       [store, store_2].each(&:reload)
-      
-      Spree::Store.default.count.should == 1
-      store_2.default.should be_true
-      store.default.should_not be_true
+
+      expect(Spree::Store.default.count) == 1
+      expect(store_2.default).to be_truthy
+      expect(store.default).not_to be_truthy
     end
   end
 end

--- a/spec/models/spree/tracker_spec.rb
+++ b/spec/models/spree/tracker_spec.rb
@@ -10,6 +10,6 @@ describe Spree::Tracker do
   end
 
   it "should pull out the current tracker" do
-    Spree::Tracker.current('www.example.com').should == @tracker
+    expect(Spree::Tracker.current('www.example.com')) == @tracker
   end
 end

--- a/spec/requests/global_controller_helpers_spec.rb
+++ b/spec/requests/global_controller_helpers_spec.rb
@@ -10,15 +10,15 @@ describe "Global controller helpers" do
   end
 
   it "should include the right tracker" do
-    response.body.should include(@tracker.analytics_id)
+    expect(response.body).to include(@tracker.analytics_id)
   end
 
   it "should create a store-aware order" do
-    controller.current_store.should == store
+    expect(controller.current_store) == store
   end
 
   it "should instantiate the correct store-bound tracker" do
-    controller.current_tracker.should == @tracker
+    expect(controller.current_tracker) == @tracker
   end
 
   describe '.current_currency' do

--- a/spec/requests/template_renderer_spec.rb
+++ b/spec/requests/template_renderer_spec.rb
@@ -13,13 +13,13 @@ describe "Template renderer with dynamic layouts" do
     FactoryGirl.create :store
 
     get "http://www.example.com"
-    response.body.should eql("Store layout hello")
+    expect(response.body).to eql("Store layout hello")
   end
 
   it "should fall back to the default layout if none are found for the current store" do
     ApplicationController.stub(:current_store).and_return(nil)
 
     get "http://www.example.com"
-    response.body.should eql("Store layout hello")
+    expect(response.body).to eql("Store layout hello")
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,8 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
+  config.infer_spec_type_from_file_location!
+
   config.include FactoryGirl::Syntax::Methods
   config.include Spree::TestingSupport::ControllerRequests
   config.include Spree::TestingSupport::Preferences, :type => :controller

--- a/spree_multi_domain.gemspec
+++ b/spree_multi_domain.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'spree', '~> 2.2.0'
 
-  s.add_development_dependency 'capybara', '~> 1.1.4'
+  s.add_development_dependency 'capybara', '~> 2.2.0'
   s.add_development_dependency 'coffee-rails'
-  s.add_development_dependency 'factory_girl', '~> 4.3.0'
+  s.add_development_dependency 'factory_girl', '~> 4.5.0'
   s.add_development_dependency 'ffaker'
-  s.add_development_dependency 'rspec-rails',  '~> 2.7'
+  s.add_development_dependency 'rspec-rails',  '~> 3.0'
   s.add_development_dependency 'spree_multi_currency'
   s.add_development_dependency 'sqlite3'
 end


### PR DESCRIPTION
`bonobos/spree` now uses rspec 3 which is causing problems for this gem because it relies on the factories and code in `bonobos/spree`.