### PR TITLE
Allow current store to be set via SPREE_STORE request header

### DIFF
--- a/app/models/spree/store.rb
+++ b/app/models/spree/store.rb
@@ -13,7 +13,7 @@ module Spree
     has_and_belongs_to_many :promotion_rules, :class_name => 'Spree::Promotion::Rules::Store', :join_table => 'spree_promotion_rules_stores', :association_foreign_key => 'promotion_rule_id'
 
     validates_presence_of :name, :code, :domains
-    
+
     before_create :ensure_default_exists_and_is_unique
 
     scope :default, lambda { where(:default => true) }
@@ -26,8 +26,8 @@ module Spree
       :path => 'stores/:id/:style/:basename.:extension',
       :convert_options => { :all => '-strip -auto-orient' }
 
-    def self.current(domain = nil)
-      current_store = domain ? Store.by_domain(domain).first : nil
+    def self.current(store_key = nil)
+      current_store = Store.find_by(code: store_key) || Store.by_domain(store_key).first
       current_store || first_found_default
     end
 

--- a/app/models/spree/tracker_decorator.rb
+++ b/app/models/spree/tracker_decorator.rb
@@ -1,7 +1,7 @@
 Spree::Tracker.class_eval do
   belongs_to :store
 
-  def self.current(domain)
-    Spree::Tracker.where(:active => true, :environment => Rails.env).joins(:store).where("spree_stores.domains LIKE ?", "%#{domain}%").first
+  def self.current(store_key)
+    Spree::Tracker.where(active: true, environment: Rails.env).joins(:store).where("spree_stores.code = ? OR spree_stores.domains LIKE ?", store_key, "%#{store_key}%").first
   end
 end

--- a/lib/spree_multi_domain/multi_domain_helpers.rb
+++ b/lib/spree_multi_domain/multi_domain_helpers.rb
@@ -10,11 +10,11 @@ module SpreeMultiDomain
     end
 
     def current_store
-      @current_store ||= Spree::Store.current(request.env['SERVER_NAME'])
+      @current_store ||= Spree::Store.current(store_key)
     end
 
     def current_tracker
-      @current_tracker ||= Spree::Tracker.current(request.env['SERVER_NAME'])
+      @current_tracker ||= Spree::Tracker.current(store_key)
     end
 
     def get_taxonomies
@@ -25,6 +25,11 @@ module SpreeMultiDomain
 
     def add_current_store_id_to_params
       params[:current_store_id] = current_store.try(:id)
+    end
+
+    private
+    def store_key
+      request.headers['SPREE_STORE'] || request.env['SERVER_NAME']
     end
   end
 end

--- a/spec/models/spree/store_spec.rb
+++ b/spec/models/spree/store_spec.rb
@@ -1,33 +1,42 @@
 require 'spec_helper'
 
 describe Spree::Store do
+  let!(:default_store) { FactoryGirl.create(:store, :default => true, :domains => "default.com") }
+  let!(:store_2)       { FactoryGirl.create(:store, :code => 'STORE2', :domains => 'freethewhales.com') }
+  let!(:store_3)       { FactoryGirl.create(:store, :code => 'STORE3', :domains => "website1.com\nwww.subdomain.com") }
 
-  describe "by_domain" do
-    let!(:store)    { FactoryGirl.create(:store, :domains => "website1.com\nwww.subdomain.com") }
-    let!(:store_2)  { FactoryGirl.create(:store, :domains => 'freethewhales.com') }
+  it "should find stores by domain" do
+    by_domain = Spree::Store.by_domain('www.subdomain.com')
 
-    it "should find stores by domain" do
-      by_domain = Spree::Store.by_domain('www.subdomain.com')
+    expect(by_domain).to include(store_3)
+    expect(by_domain).not_to include(default_store)
+    expect(by_domain).not_to include(store_2)
+  end
 
-      expect(by_domain).to include(store)
-      expect(by_domain).not_to include(store_2)
-    end
+  it "should find the current store by domain" do
+    current_store = Spree::Store.current('website1.com')
+
+    expect(current_store) == store_3
+  end
+
+  it "should find the current store by code" do
+    current_store = Spree::Store.current('STORE2')
+
+    expect(current_store) == store_2
   end
 
   describe "default" do
-    let!(:store)    { FactoryGirl.create(:store) }
-    let!(:store_2)  { FactoryGirl.create(:store, default: true) }
-
     it "should ensure there is a default if one doesn't exist yet" do
-      expect(store.default).to be_truthy
+      expect(default_store.default).to be_truthy
     end
 
     it "should ensure there is only one default" do
-      [store, store_2].each(&:reload)
+      [default_store, store_2, store_3].each(&:reload)
 
       expect(Spree::Store.default.count) == 1
-      expect(store_2.default).to be_truthy
-      expect(store.default).not_to be_truthy
+      expect(default_store.default).to be_truthy
+      expect(store_2.default).to be_falsey
+      expect(store_3.default).to be_falsey
     end
   end
 end

--- a/spec/models/spree/tracker_spec.rb
+++ b/spec/models/spree/tracker_spec.rb
@@ -2,14 +2,18 @@ require 'spec_helper'
 
 describe Spree::Tracker do
   before(:each) do
-    store = FactoryGirl.create(:store)
+    store = FactoryGirl.create(:store, :default => true)
     @tracker = FactoryGirl.create(:tracker, :store => store)
 
-    another_store = FactoryGirl.create(:store, :domains => 'completely-different-store.com')
+    another_store = FactoryGirl.create(:store, :code => 'STORE2', :domains => 'completely-different-store.com')
     @tracker2 = FactoryGirl.create(:tracker, :store => another_store)
   end
 
-  it "should pull out the current tracker" do
+  it "should pull out the current tracker based on store code" do
+    expect(Spree::Tracker.current('STORE2')) == @tracker
+  end
+
+  it "should pull out the current tracker based on domains" do
     expect(Spree::Tracker.current('www.example.com')) == @tracker
   end
 end


### PR DESCRIPTION
This PR adds another method for current store to be loaded, if a `SPREE_STORE` request header is set and matches a `Spree::Store` code attribute, then it'll return that store. If not, it'll default to host name based look up. This makes it easier in certain environments for API requests specifically to target stores rather than setup a different host name for each store.

Example request headers:
```
SPREE_STORE: 'BNBS' # Load the Bonobos store
SPREE_STORE: 'AYR' # Load Ayr store
```